### PR TITLE
Convert to a proper minor mode

### DIFF
--- a/features/sql-indent.feature
+++ b/features/sql-indent.feature
@@ -3,6 +3,7 @@ Feature: Basic indentation
     When the buffer is empty
     When I turn on sql-mode
     When I set indent-tabs-mode to nil
+    When I turn on sql-indent-mode
 
 
   Scenario: Indent unindented SELECT statement

--- a/sql-indent.el
+++ b/sql-indent.el
@@ -185,10 +185,18 @@ Return a list containing the level change and the previous indentation."
     )
   )
 
-(add-hook 'sql-mode-hook
-	  (function (lambda ()
-		      (make-local-variable 'indent-line-function)
-		      (setq indent-line-function 'sql-indent-line))))
+(define-minor-mode sql-indent-mode
+  "A minor mode enabling more intelligent sql indentation"
+  :global nil
+
+  ;; body
+  (when sql-indent-mode
+    (make-local-variable 'indent-line-function)
+    (setq indent-line-function 'sql-indent-line))
+
+  (unless sql-indent-mode
+    (kill-local-variable 'indent-line-function)))
+
 
 (provide 'sql-indent)
 


### PR DESCRIPTION
Hi,

I think sql-indent should be a minor mode (it's uncommon to have code which does something merely by loading it). However changing it to a minor mode now will break peoples configs, which is probably bad, thoughts?

We could also add a custom variable (defaulting to `t`) and add the hook automatically as it does at the moment if it is true. This would avoid breaking existing configs, but is a bit of a hack. 